### PR TITLE
Fixes issue #8 by providing a default 'where' value

### DIFF
--- a/core/components/archivist/elements/snippets/snippet.getarchives.php
+++ b/core/components/archivist/elements/snippets/snippet.getarchives.php
@@ -49,7 +49,7 @@ if ($modx->getOption('makeArchive',$scriptProperties,true)) {
 }
 
 /* get filter by year, month, and/or day. Sanitize to prevent injection. */
-$where = $modx->getOption('where',$scriptProperties,false);
+$where = $modx->getOption('where',$scriptProperties,"[]");
 $where = is_array($where) ? $where : $modx->fromJSON($where);
 $parameters = $modx->request->getParameters();
 


### PR DESCRIPTION
There's been an issue with PHP7 (or MODX 2.5.7 - not totally sure which) where the user must add a &where=`[]` to the getArchives call to avoid a server 500 error.

This update provides that default in the snippet if no setting has been passed from the snippet call.