### PR TITLE
Don't break on an invalid where clause

### DIFF
--- a/core/components/archivist/elements/snippets/snippet.getarchives.php
+++ b/core/components/archivist/elements/snippets/snippet.getarchives.php
@@ -51,6 +51,7 @@ if ($modx->getOption('makeArchive',$scriptProperties,true)) {
 /* get filter by year, month, and/or day. Sanitize to prevent injection. */
 $where = $modx->getOption('where',$scriptProperties,false);
 $where = is_array($where) ? $where : $modx->fromJSON($where);
+$where = is_array($where) ? $where : array();
 $parameters = $modx->request->getParameters();
 
 $year = $modx->getOption($filterPrefix.'year',$parameters,$modx->getOption('year',$scriptProperties,''));


### PR DESCRIPTION
$where is null without that check and afterwards it is used as array. PHP 7.2+ does not like that.