### PR TITLE
Fix fatal error on modern PHP

### DIFF
--- a/core/components/archivist/elements/snippets/snippet.archivist.php
+++ b/core/components/archivist/elements/snippets/snippet.archivist.php
@@ -133,7 +133,7 @@ $c->sortby('FROM_UNIXTIME(`'.$sortBy.'`,"%Y") '.$sortDir.', FROM_UNIXTIME(`'.$so
 $c->groupby('FROM_UNIXTIME(`'.$sortBy.'`,"'.$sqlDateFormat.'")');
 /* if limiting to X records */
 if (!empty($limit)) { $c->limit($limit,$start); }
-$resources = $modx->getIterator('modResource',$c);
+$resources = $modx->getCollection('modResource',$c);
 
 /* iterate over resources */
 $output = array();


### PR DESCRIPTION
This is a quick fix that replaces the use of getIterator with getCollection. `count()` is expecting a countable value.
